### PR TITLE
Fixed bug that ruined game settings and generated errors

### DIFF
--- a/ProfessionMaster.lua
+++ b/ProfessionMaster.lua
@@ -77,14 +77,14 @@ end
 --- Check settings.
 function ProfessionMasterAddon:CheckSettings()
     -- check settings
-    if (not Settings) then 
-        Settings = {}; 
+    if (not PMSettings) then 
+        PMSettings = {}; 
     end
-    if (not Settings.storageId) then
-        Settings.storageId = self:GenerateString(12);
+    if (not PMSettings.storageId) then
+        PMSettings.storageId = self:GenerateString(12);
     end
-    if (not Settings.minimapButton) then
-        Settings.minimapButton = {
+    if (not PMSettings.minimapButton) then
+        PMSettings.minimapButton = {
             hide = false
         };
     end
@@ -315,18 +315,18 @@ end
 -- Migrate data.
 function ProfessionMasterAddon:Migrate()
     -- check data version
-    if (Settings.storeVersion and Settings.storeVersion < 3) then
+    if (PMSettings.storeVersion and PMSettings.storeVersion < 3) then
         -- clear data
         Professions = {};
         OwnProfessions = {};
         SyncTimes = {};
         CharacterSettings = {}; 
-        Settings = {};
+        PMSettings = {};
         self:CheckSettings();
     end
 
     -- check data version
-    if (Settings.storeVersion and Settings.storeVersion < 5) then
+    if (PMSettings.storeVersion and PMSettings.storeVersion < 5) then
         -- check all professions
         for professionId, profession in pairs(Professions) do  
             -- prepare valid skills
@@ -369,7 +369,7 @@ function ProfessionMasterAddon:Migrate()
     end
 
     -- set store version
-    Settings.storeVersion = 5;
+    PMSettings.storeVersion = 5;
 end
 
 -- create addon

--- a/ProfessionMaster.toc
+++ b/ProfessionMaster.toc
@@ -1,10 +1,10 @@
 ## Author: Esperanza - Everlook/EU-Alliance
-## Interface: 30401
+## Interface: 30402
 ## Title: Profession Master |cffDA8CFF[PM]
 ## Notes: See your professions, those of your guild and those of your friends.
 ## Notes-deDE: Siehe deine Berufe, die deiner Gilde und die deiner Freunde ein.
-## Version: 1.6.2
-## SavedVariables: Professions, OwnProfessions, SyncTimes, Settings, Logs, CharacterSets, BucketList, Guildmates
+## Version: 1.6.4
+## SavedVariables: Professions, OwnProfessions, SyncTimes, PMSettings, Logs, CharacterSets, BucketList, Guildmates
 ## SavedVariablesPerCharacter: Frames, CharacterSettings
 
 libs\LibStub.lua

--- a/services/commands-service.lua
+++ b/services/commands-service.lua
@@ -41,7 +41,7 @@ local function CommandHandler(parameters)
         chatService:Write("CommandsTitle");
         chatService:Write("CommandsOverview");
         chatService:Write("CommandsReagents");
-        if (Settings.minimapButton.hide) then
+        if (PMSettings.minimapButton.hide) then
             chatService:Write("CommandsMinimap");
         end
         chatService:Write("CommandsPurge");
@@ -57,7 +57,7 @@ local function CommandHandler(parameters)
     -- check if minimap should be toggeled
     if (string.lower(parameters) == "minimap") then
         LibStub("LibDBIcon-1.0"):Show("ProfessionMaster");
-        Settings.minimapButton.hide = false;
+        PMSettings.minimapButton.hide = false;
         return;
     end
 

--- a/services/inventory-service.lua
+++ b/services/inventory-service.lua
@@ -99,7 +99,7 @@ end
 -- Check for missing reagents.
 function InventoryService:CheckMissingReagents()
     -- check if missing reagents should be hidden
-    if (Settings.hideMissingReagents) then
+    if (PMSettings.hideMissingReagents) then
         return;
     end
 
@@ -132,13 +132,13 @@ function InventoryService:ToggleMissingReagents()
     -- check if visible
     if (self.missingReagentsView.visible) then
         --hide missing reagents
-        Settings.hideMissingReagents = true;
+        PMSettings.hideMissingReagents = true;
         self.missingReagentsView:Hide();
         return;
     end
 
     -- do not hide missing ragents
-    Settings.hideMissingReagents = nil;
+    PMSettings.hideMissingReagents = nil;
     self:CheckMissingReagents();
 end
 

--- a/services/own-professions-service.lua
+++ b/services/own-professions-service.lua
@@ -257,7 +257,7 @@ function OwnProfessionsService:SendOwnProfessionToPlayer(playerName, professionI
             -- check if 8 skills added
             if (#messageSkills == 8) then
                 -- send message
-                messageService:SendToPlayer(playerName, PlayerProfessionsMessage:Create(professionId, Settings.storageId, ownPlayerName, messageSkills));
+                messageService:SendToPlayer(playerName, PlayerProfessionsMessage:Create(professionId, PMSettings.storageId, ownPlayerName, messageSkills));
                 messageSkills = {};
             end
         end
@@ -266,7 +266,7 @@ function OwnProfessionsService:SendOwnProfessionToPlayer(playerName, professionI
     -- check if skills to send
     if (#messageSkills > 0) then
         -- send message
-        messageService:SendToPlayer(playerName, PlayerProfessionsMessage:Create(professionId, Settings.storageId, ownPlayerName, messageSkills)); 
+        messageService:SendToPlayer(playerName, PlayerProfessionsMessage:Create(professionId, PMSettings.storageId, ownPlayerName, messageSkills)); 
     end
 end
 

--- a/services/professions-service.lua
+++ b/services/professions-service.lua
@@ -73,7 +73,7 @@ end
 --- Say hello to guild.
 function ProfessionsService:SayHelloToGuild()
     -- send hello message to guild
-    addon:GetService("message"):SendToGuild(addon:GetModel("hello-message"):Create(Settings.storageId));
+    addon:GetService("message"):SendToGuild(addon:GetModel("hello-message"):Create(PMSettings.storageId));
 end
 
 --- Request profession from other player.
@@ -82,7 +82,7 @@ function ProfessionsService:RequestProfessionsFromPlayer(playerName, playerStora
     local lastSyncDate = self:GetLastSyncDate(playerStorageId);
 
     -- send request professions message to player
-    addon:GetService("message"):SendToPlayer(playerName, addon:GetModel("request-professions-message"):Create(Settings.storageId, lastSyncDate, sendBack));
+    addon:GetService("message"):SendToPlayer(playerName, addon:GetModel("request-professions-message"):Create(PMSettings.storageId, lastSyncDate, sendBack));
 end
 
 --- Get last sync date of storage.

--- a/services/purge-service.lua
+++ b/services/purge-service.lua
@@ -37,7 +37,7 @@ function PurgeService:Purge(context)
         Professions = {};
         OwnProfessions = {};
         SyncTimes = {};
-        Settings = {};
+        PMSettings = {};
         Logs = {};
         CharacterSets = {};
         BucketList = {};
@@ -94,7 +94,7 @@ function PurgeService:PurgeCharacter(characterName)
     SyncTimes = {};
 
     -- reset storage id to recieve data again
-    Settings.storageId = nil;
+    PMSettings.storageId = nil;
 
     -- check settings
     addon:CheckSettings();

--- a/services/ui-service.lua
+++ b/services/ui-service.lua
@@ -43,7 +43,7 @@ function UiService:CreateView(name, width, height, title)
     view.positionName = name;
     view:SetFrameLevel(currentZIndex);
     view:SetBackdrop({
-        bgFile = [[Interface/AddOns/nAuras/Media/BackgroundFlat]],
+        bgFile = [[Interface/Buttons/WHITE8X8]],
         edgeFile = [[Interface/Buttons/WHITE8X8]],
         edgeSize = 1
     });
@@ -277,7 +277,7 @@ function UiService:CreateMinimapIcon()
             elseif (button == "RightButton") then
                 if (IsShiftKeyDown()) then
                     libDbIcon:Hide("ProfessionMaster");
-                    Settings.minimapButton.hide = true;
+                    PMSettings.minimapButton.hide = true;
                 else
                     addon:GetService("inventory"):ToggleMissingReagents();
                 end
@@ -294,7 +294,7 @@ function UiService:CreateMinimapIcon()
 	})
 
     -- show minimap button
-	libDbIcon:Register("ProfessionMaster", dataObj, Settings.minimapButton);
+	libDbIcon:Register("ProfessionMaster", dataObj, PMSettings.minimapButton);
 end
 
 -- register service

--- a/views/professions-view.lua
+++ b/views/professions-view.lua
@@ -263,8 +263,8 @@ function ProfessionsView:Show()
         self.skillViewBackground = skillViewBackground;
 
         -- select first profession
-        self:SelectProfession(Settings.lastProfession or 0);
-        self:SelectAddon(Settings.lastAddon);
+        self:SelectProfession(PMSettings.lastProfession or 0);
+        self:SelectAddon(PMSettings.lastAddon);
     end
 
     -- hide skill view
@@ -366,7 +366,7 @@ end
 function ProfessionsView:SelectProfession(professionId)
     -- set profession id
     self.professionId = professionId;
-    Settings.lastProfession = professionId;
+    PMSettings.lastProfession = professionId;
 
     -- select dropdown
     UIDropDownMenu_SetText(self.professionSelection, self:GetProfessionText(professionId));
@@ -397,7 +397,7 @@ end
 function ProfessionsView:SelectAddon(addonId)
     -- set addon id
     self.addonId = addonId;
-    Settings.lastAddon = addonId;
+    PMSettings.lastAddon = addonId;
 
     -- select dropdown
     UIDropDownMenu_SetText(self.addonSelection, self:GetAddonText(addonId));


### PR DESCRIPTION
Global variable name 'Settings' was interfering with a Blizzard global.
Renamed all instances to 'PMSettings'.
I'm Recommending to rename the other SavedVariables (Globals) to unique names to avoid this in the future.