### PR TITLE
Add table of contents for Vanilla/TBC/Wrath

### DIFF
--- a/ProfessionMaster.lua
+++ b/ProfessionMaster.lua
@@ -38,9 +38,6 @@ if (not Guildmates) then Guildmates = {}; end
 
 --- Create new addon container.
 function ProfessionMasterAddon:Create()
-    -- get wow build
-    local wowBuild = GetBuildInfo();
-
     -- create addon and add empty holders
     local addon = {
         name = addonName,
@@ -51,7 +48,7 @@ function ProfessionMasterAddon:Create()
         frame = CreateFrame("Frame"),
         logLevel = 0,
         loaded = false,
-        isEra = string.find(wowBuild, "1.") == 1
+        isEra = _G.WOW_PROJECT_ID == _G.WOW_PROJECT_CLASSIC
     };
     setmetatable(addon, ProfessionMasterAddon);
     

--- a/ProfessionMaster_TBC.toc
+++ b/ProfessionMaster_TBC.toc
@@ -1,8 +1,5 @@
 ## Author: Esperanza - Everlook/EU-Alliance
-## Interface: 30403
-## Interface-Classic: 11500
-## Interface-BCC: 20504
-## Interface-Wrath: 30403
+## Interface: 20504
 ## Title: Profession Master |cffDA8CFF[PM]
 ## Notes: See your professions, those of your guild and those of your friends.
 ## Notes-deDE: Siehe deine Berufe, die deiner Gilde und die deiner Freunde ein.

--- a/ProfessionMaster_Vanilla.toc
+++ b/ProfessionMaster_Vanilla.toc
@@ -1,8 +1,5 @@
 ## Author: Esperanza - Everlook/EU-Alliance
-## Interface: 30403
-## Interface-Classic: 11500
-## Interface-BCC: 20504
-## Interface-Wrath: 30403
+## Interface: 11500
 ## Title: Profession Master |cffDA8CFF[PM]
 ## Notes: See your professions, those of your guild and those of your friends.
 ## Notes-deDE: Siehe deine Berufe, die deiner Gilde und die deiner Freunde ein.

--- a/ProfessionMaster_Wrath.toc
+++ b/ProfessionMaster_Wrath.toc
@@ -1,8 +1,5 @@
 ## Author: Esperanza - Everlook/EU-Alliance
 ## Interface: 30403
-## Interface-Classic: 11500
-## Interface-BCC: 20504
-## Interface-Wrath: 30403
 ## Title: Profession Master |cffDA8CFF[PM]
 ## Notes: See your professions, those of your guild and those of your friends.
 ## Notes-deDE: Siehe deine Berufe, die deiner Gilde und die deiner Freunde ein.


### PR DESCRIPTION
Allow loading the addon from within Classic Era with these changes. At present, the current table of contents file lists only a single interface version for Wrath Classic.